### PR TITLE
Added code to create project check-out directory

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,7 @@ using namespace boost::filesystem;
 boost::filesystem::fstream fileOp;
 
 const string cmdList[] = {"Exit", "View Project Source Directory", "View Project Repo Directory",
-  "Create Project Repository", "Project Check-Out", "Project Check-In"};
+                          "Create Project Repository", "Project Check-Out", "Project Check-In"};
 
 ptime invalidTime = time_from_string("1900-01-01 08:00:00");
 


### PR DESCRIPTION
check-out directory is created on the desktop under name "VCS_Proj_Fork<#>"
Removed "file_mapping.hpp" & "mapped_region.hpp" include directives.
Moved "ArgList" struct above the function prototypes.